### PR TITLE
add python 3.6 builds on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,14 @@ environment:
       PYTHON_VERSION: "3.5.x" # currently 3.5.1
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.0
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.0
+      PYTHON_ARCH: "64"
+
 install:
   - cmd: echo "Using cmd"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
   - pip install wheel==0.26
   - git submodule update --init
   # Dependencies for package
-  - pip install numpy==1.10.4 Cython nose
+  - pip install numpy==1.11.3 Cython nose
 
 build_script:
   # Build and install the wheel


### PR DESCRIPTION
updating to generate Python 3.6 windows wheels for PyPI