### PR TITLE
MAINT: try Python 3.6 appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,8 @@ environment:
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
             9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
+      NP_BUILD_DEP: "1.10.4"
+      NP_TEST_DEP: "1.10.4"
 
     matrix:
 
@@ -43,6 +45,18 @@ environment:
       PYTHON_VERSION: "3.5.x" # currently 3.5.1
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.0
+      PYTHON_ARCH: "32"
+      NP_BUILD_DEP: "1.11.3"
+      NP_TEST_DEP: "1.11.3"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.0
+      PYTHON_ARCH: "64"
+      NP_BUILD_DEP: "1.11.3"
+      NP_TEST_DEP: "1.11.3"
+
 install:
   - cmd: echo "Using cmd"
 
@@ -65,7 +79,7 @@ install:
   - pip install wheel==0.26
   - git submodule update --init
   # Dependencies for package
-  - pip install numpy==1.10.4 Cython nose
+  - pip install numpy==%NP_BUILD_DEP% Cython
 
 build_script:
   # Build and install the wheel
@@ -81,6 +95,7 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
+  - pip install numpy==%NP_TEST_DEP% nose
   - nosetests ..\pywt\tests
   - cd ..
 


### PR DESCRIPTION
Updating numpy only for Python 3.6, to maintain backwards compatibility
with earlier numpy versions, on earlier Pythons.