### PR TITLE
Build v1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP pytest"
+    - TEST_DEPENDS="$NP_TEST_DEP pytest nose"  # numpy < 1.15 still require nose
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,29 +26,6 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.5
         - NP_BUILD_DEP=numpy==1.9.3
         - NP_TEST_DEP=numpy==1.9.3
@@ -80,13 +57,6 @@ matrix:
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
-    - os: osx
-      language: generic
-      env: MB_PYTHON_VERSION=2.7
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.4
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ env:
       - BUILD_COMMIT=master
       - PLAT=x86_64
       - UNICODE_WIDTH=32
-      - NP_BUILD_DEP="numpy==1.10.4"
-      - NP_TEST_DEP="numpy==1.15.4"  # >=1.15 so NumPy uses with pytest
+      - NP_BUILD_DEP="numpy==1.13.3"
+      - NP_TEST_DEP="numpy==1.15.4"  # >=1.15 so NumPy works with pytest
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       - EXTRA_ARGV="'--disable-pytest-warnings'"
       # Following generated with
@@ -28,36 +28,26 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
@@ -73,13 +63,13 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.9.3
+        - NP_BUILD_DEP=numpy==1.13.3
         - NP_TEST_DEP=numpy==1.15.4
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.13.3
         - NP_TEST_DEP=numpy==1.15.4
     - os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
       - NP_BUILD_DEP="numpy==1.10.4"
       - NP_TEST_DEP="numpy==1.10.4"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
+      - EXTRA_ARGV="'--disable-pytest-warnings'"
       # Following generated with
       # travis encrypt -r scikit-image/scikit-image-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
       - secure:
@@ -95,7 +96,7 @@ matrix:
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP nose"
+    - TEST_DEPENDS="$NP_TEST_DEP pytest"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 env:
   global:
       - REPO_DIR="pywt"
-      - BUILD_COMMIT=v1.0.3
+      - BUILD_COMMIT=master
       - PLAT=x86_64
       - UNICODE_WIDTH=32
-      - NP_BUILD_DEP="numpy==1.9.1"
-      - NP_TEST_DEP="numpy==1.9.1"
+      - NP_BUILD_DEP="numpy==1.10.4"
+      - NP_TEST_DEP="numpy==1.10.4"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with
       # travis encrypt -r scikit-image/scikit-image-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,18 +69,21 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
+        - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP=numpy==1.13.3
         - NP_TEST_DEP=numpy==1.15.4
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
+        - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.15.4
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.8
+        - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP=numpy==1.17.3
         - NP_TEST_DEP=numpy==1.17.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
       - REPO_DIR="pywt"
-      - BUILD_COMMIT=master
+      - BUILD_COMMIT=v1.1.0
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.13.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.10.4"
-      - NP_TEST_DEP="numpy==1.10.4"
+      - NP_TEST_DEP="numpy==1.15.4"  # >=1.15 so NumPy uses with pytest
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       - EXTRA_ARGV="'--disable-pytest-warnings'"
       # Following generated with
@@ -29,35 +29,35 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.5
         - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
+        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
+        - NP_TEST_DEP=numpy==1.15.4
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
@@ -74,19 +74,19 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.5
         - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_TEST_DEP=numpy==1.15.4
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_TEST_DEP=numpy==1.15.4
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
+        - NP_TEST_DEP=numpy==1.15.4
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,17 @@ matrix:
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - PLAT=i686
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
     - os: osx
       language: generic
       env:
@@ -75,6 +86,12 @@ matrix:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython"

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP pytest nose"  # numpy < 1.15 still require nose
+    - TEST_DEPENDS="$NP_TEST_DEP pytest"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,9 @@ environment:
 install:
   - cmd: echo "Using cmd"
 
+  # Install new Python if necessary
+  - ps: .\multibuild\install_python.ps1
+
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,14 @@ environment:
     - PYTHON: C:\Python35-x64
 
 install:
-  - cmd: echo "Using cmd"
+  - cmd: echo "Filesystem root:"
+  - dir C:\
+
+  - echo "Installed SDKs:"
+  - dir "C:/Program Files/Microsoft SDKs/Windows"
+
+  # Get needed submodules
+  - git submodule update --init
 
   # Install new Python if necessary
   - ps: .\multibuild\install_python.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,8 +85,8 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
-  - pip install numpy==%NP_TEST_DEP% nose
-  - nosetests ..\pywt\tests
+  - pip install numpy==%NP_TEST_DEP% pytest
+  - pytest --pyargs pywt
   - cd ..
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,9 +62,9 @@ install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
 
-  - python -m pip install --upgrade pip
-  # Pin wheel to 0.26 to avoid Windows ABI tag for built wheel
-  - pip install wheel==0.26
+  # Upgrade to the latest pip, setuptools, and wheel
+  - python -m pip install --upgrade pip setuptools wheel
+
   - git submodule update --init
   # Dependencies for package
   - pip install numpy==%NP_BUILD_DEP% Cython

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
-  - pip install numpy==%NP_TEST_DEP% pytest
+  - pip install numpy==%NP_TEST_DEP% pytest nose  # numpy < 1.15 still require nose
   - pytest --pyargs pywt
   - cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
             9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
-      NP_BUILD_DEP: "1.10.4"
+      NP_BUILD_DEP: "1.13.3"
       NP_TEST_DEP: "1.15.4"
 
     matrix:
@@ -28,16 +28,10 @@ environment:
       NP_TEST_DEP: "1.17.3"
     - PYTHON: C:\Python37
       NP_BUILD_DEP: "1.14.5"
-      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python37-x64
       NP_BUILD_DEP: "1.14.5"
-      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python36
-      NP_BUILD_DEP: "1.11.3"
-      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python36-x64
-      NP_BUILD_DEP: "1.11.3"
-      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python35
     - PYTHON: C:\Python35-x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,7 +95,7 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
-  - pip install numpy==%NP_TEST_DEP% pytest nose  # numpy < 1.15 still require nose
+  - pip install numpy==%NP_TEST_DEP% pytest
   - pytest --pyargs pywt
   - cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ os: Visual Studio 2015
 environment:
     global:
       # Remember to edit .travis.yml too
-      BUILD_COMMIT: v1.0.3
+      BUILD_COMMIT: master
       WHEELHOUSE_UPLOADER_USERNAME: travis-worker
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
@@ -20,6 +20,12 @@ environment:
       NP_TEST_DEP: "1.10.4"
 
     matrix:
+    - PYTHON: C:\Python38
+      NP_BUILD_DEP: "1.17.3"
+      NP_TEST_DEP: "1.17.3"
+    - PYTHON: C:\Python38-x64
+      NP_BUILD_DEP: "1.17.3"
+      NP_TEST_DEP: "1.17.3"
     - PYTHON: C:\Python37
       NP_BUILD_DEP: "1.14.5"
       NP_TEST_DEP: "1.14.5"
@@ -34,8 +40,6 @@ environment:
       NP_TEST_DEP: "1.11.3"
     - PYTHON: C:\Python35
     - PYTHON: C:\Python35-x64
-    - PYTHON: C:\Python27
-    - PYTHON: C:\Python27-x64
 
 install:
   - cmd: echo "Using cmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ os: Visual Studio 2015
 environment:
     global:
       # Remember to edit .travis.yml too
-      BUILD_COMMIT: master
+      BUILD_COMMIT: v1.1.0
       WHEELHOUSE_UPLOADER_USERNAME: travis-worker
       WHEELHOUSE_UPLOADER_SECRET:
         secure:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
         secure:
             9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
       NP_BUILD_DEP: "1.10.4"
-      NP_TEST_DEP: "1.10.4"
+      NP_TEST_DEP: "1.15.4"
 
     matrix:
     - PYTHON: C:\Python38
@@ -28,16 +28,16 @@ environment:
       NP_TEST_DEP: "1.17.3"
     - PYTHON: C:\Python37
       NP_BUILD_DEP: "1.14.5"
-      NP_TEST_DEP: "1.14.5"
+      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python37-x64
       NP_BUILD_DEP: "1.14.5"
-      NP_TEST_DEP: "1.14.5"
+      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python36
       NP_BUILD_DEP: "1.11.3"
-      NP_TEST_DEP: "1.11.3"
+      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python36-x64
       NP_BUILD_DEP: "1.11.3"
-      NP_TEST_DEP: "1.11.3"
+      NP_TEST_DEP: "1.15.4"
     - PYTHON: C:\Python35
     - PYTHON: C:\Python35-x64
 

--- a/config.sh
+++ b/config.sh
@@ -7,8 +7,15 @@ function pre_build {
     :
 }
 
+function get_test_cmd {
+    local extra_argv=${1:-$EXTRA_ARGV}
+    echo "import sys; import pywt; \
+        sys.exit(not pywt.test('full', \
+        extra_argv=[${extra_argv}]))"
+}
+
 function run_tests {
     # Runs tests on installed distribution from an empty directory
     python --version
-    nosetests ../pywt/pywt/tests
+    python -c "$(get_test_cmd)"
 }


### PR DESCRIPTION
This PR is to build wheels for Python 3.5-3.8.

It incorporates the changes from #9 that were needed for the switch to pytest and to add Python 3.8 while dropping 2.7 and 3.4.