### PR TITLE
Add config to build aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ jobs:
     - env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
+    - arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - NP_BUILD_DEP=numpy==1.19.2
+        - NP_TEST_DEP=numpy==1.19.2
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
     - env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
@@ -29,6 +37,14 @@ jobs:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
+    - arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - NP_BUILD_DEP=numpy==1.19.2
+        - NP_TEST_DEP=numpy==1.19.2
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
     - env:
         - MB_PYTHON_VERSION=3.8
         - NP_BUILD_DEP=numpy==1.17.3
@@ -38,6 +54,14 @@ jobs:
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.17.3
         - NP_TEST_DEP=numpy==1.17.3
+    - arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - NP_BUILD_DEP=numpy==1.19.2
+        - NP_TEST_DEP=numpy==1.19.2
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
     - os: osx
       language: generic
       env:


### PR DESCRIPTION
Travis-CI allows for the creation of aarch64 wheels.

Note:
* This needs the latest multibuild. Update the submodule to point to the latest.