### PR TITLE
switch from Rackspace uploads to Anaconda.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP pytest"
+    - TEST_DEPENDS="$NP_TEST_DEP pytest pytest-env"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,35 +11,29 @@ env:
 language: python
 # Default Python version is usually 2.7
 python: 3.6
-sudo: required
 dist: trusty
 services: docker
+os: linux
 
-matrix:
+jobs:
   include:
-    - os: linux
-      env:
+    - env:
         - MB_PYTHON_VERSION=3.6
-    - os: linux
-      env:
+    - env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
-    - os: linux
-      env:
+    - env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
-    - os: linux
-      env:
+    - env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
-    - os: linux
-      env:
+    - env:
         - MB_PYTHON_VERSION=3.8
         - NP_BUILD_DEP=numpy==1.17.3
         - NP_TEST_DEP=numpy==1.17.3
-    - os: linux
-      env:
+    - env:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.17.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,13 @@ env:
 
 language: python
 # Default Python version is usually 2.7
-python: 3.5
+python: 3.6
 sudo: required
 dist: trusty
 services: docker
 
 matrix:
-  exclude:
-      # Exclude the default Python 3.5 build
-      - python: 3.5
   include:
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ after_success:
     # used in Appveyor CI config, originally created at
     # multibuild-wheels-staging site
     - ANACONDA_ORG="multibuild-wheels-staging";
-      TOKEN=${PYWAVELETS_STAGING_UPLOAD_TOKEN};
+    - TOKEN=${PYWAVELETS_STAGING_UPLOAD_TOKEN};
     - pip install git+https://github.com/Anaconda-Server/anaconda-client;
     - if [ -n "${TOKEN}" ] ; then
         anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,6 @@ jobs:
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.13.3
-        - NP_TEST_DEP=numpy==1.15.4
-    - os: osx
-      language: generic
-      env:
         - MB_PYTHON_VERSION=3.6
         - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP=numpy==1.13.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ env:
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.13.3"
       - NP_TEST_DEP="numpy==1.15.4"  # >=1.15 so NumPy works with pytest
-      - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       - EXTRA_ARGV="'--disable-pytest-warnings'"
-      # Following generated with
-      # travis encrypt -r scikit-image/scikit-image-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
-      - secure:
-          "m2ZsdrZuhsnDztkV/7Xu3sRF8KRTXaZzbeQ7IqvnamT3wbLFl6ZIaSogzDGmsBpcWlPp0VPxo1peYDZodFziqgxrsNncTHDVxMIeTXIYWV/MeF6UYtm/34P81641Tj50eu06CTBhuiIPNVncZti+Np4rWrkSBE8F2kVAfcrRthz8H6J0WF4+8UuN/rVRjtRPwUUnLTHhUlrKpDrsv0rG71HA8pP7iZIheM/hGHDQxqw5eN35ekPjU0Fqz9UBjwxDKk631MqQx7r1aDVdac8OnKw16NQ0YOJXIhomC3HirmlYRYRk8zwvvWtDR83kStXZhrosMNmIHz74TvFxFLyVBtGBDWRdTbjvt2tY8t3U7If8K31nqTMl6T1u+528PVTpmQf4346deFNCZ8HI9RaXPA/1yAxggDBm1D9LasE9HqUypXWvToYwSEFNrApUUMmwGmbJyvh3AI9bbs1QkogPTiNLFJTodzCJG3F28E+lzGA+uYNVSqsa4zV6wFHNpcSFR3bkMj/RfImJKzyb8cBLzhf3Q8t51qva7Ug/ouZY3M5r75Yp9UOU5e/JALipODNv5Y6Ti+lbk/kTUYn/TDXm/MzLt4SMjXfBIbeGKkWaMV4IS6ayrui/K9KEmTGFWp2bXpKyBNft6ka0ipA7C1U/eQ32PIrAeijg6wSn1tUlJag="
 
 language: python
 # Default Python version is usually 2.7
@@ -103,9 +98,13 @@ script:
     - install_run $PLAT
 
 after_success:
-    # Upload wheels to Rackspace container
-    - pip install wheelhouse-uploader
-    - python -m wheelhouse_uploader upload --local-folder
-          ${TRAVIS_BUILD_DIR}/wheelhouse/
-          --no-update-index
-          wheels
+    # Upload the generated wheel package to anaconda.org
+    # PYWAVELETS_STAGING_UPLOAD_TOKEN is an encrypted variable
+    # used in Appveyor CI config, originally created at
+    # multibuild-wheels-staging site
+    - ANACONDA_ORG="multibuild-wheels-staging";
+      TOKEN=${PYWAVELETS_STAGING_UPLOAD_TOKEN};
+    - pip install git+https://github.com/Anaconda-Server/anaconda-client;
+    - if [ -n "${TOKEN}" ] ; then
+        anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
+      fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,11 +83,11 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
-  - python -m pip install numpy==%NP_TEST_DEP% pytest
+  - python -m pip install numpy==%NP_TEST_DEP% "pytest<6"
   - python -c "import pywt; print(f'pywt version={pywt.__version__}, pywt location={pywt.__file__}')"
   - python -c "import pytest; print(f'pytest version={pytest.__version__}, ptest location={pytest.__file__}')"
-  # - python -m pytest --pyargs pywt
-  - python -c "import pywt; pywt.test()"
+  - python -m pytest --pyargs pywt
+  # - python -c "import pywt; pywt.test()"
   - cd ..
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,8 +83,11 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
-  - pip install numpy==%NP_TEST_DEP% pytest
+  - python -m pip install numpy==%NP_TEST_DEP% pytest
+  - python -c "import pywt; print(f'pywt version={pywt.__version__}, pywt location={pywt.__file__}')"
+  - python -c "import pytest; print(f'pytest version={pytest.__version__}, ptest location={pytest.__file__}')"
   - python -m pytest --pyargs pywt
+  # - python -c "import pywt; pywt.test()"
   - cd ..
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,7 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
-  - python -m pip install "numpy==%NP_TEST_DEP% pytest pytest-env"
+  - python -m pip install numpy==%NP_TEST_DEP% pytest pytest-env
   - python -m pytest --pyargs pywt
   - cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,6 @@ environment:
       NP_BUILD_DEP: "1.14.5"
     - PYTHON: C:\Python36
     - PYTHON: C:\Python36-x64
-    - PYTHON: C:\Python35
-    - PYTHON: C:\Python35-x64
 
 install:
   - cmd: echo "Filesystem root:"
@@ -86,7 +84,7 @@ test_script:
   - mkdir tmp
   - cd tmp
   - pip install numpy==%NP_TEST_DEP% pytest
-  - pytest --pyargs pywt
+  - python -m pytest --pyargs pywt
   - cd ..
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,6 @@ environment:
     global:
       # Remember to edit .travis.yml too
       BUILD_COMMIT: v1.1.1
-      WHEELHOUSE_UPLOADER_USERNAME: travis-worker
-      WHEELHOUSE_UPLOADER_SECRET:
-        secure:
-            9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
       NP_BUILD_DEP: "1.13.3"
       NP_TEST_DEP: "1.15.4"
 
@@ -98,10 +94,11 @@ after_test:
   - dir dist
 
 on_success:
-  # Upload the generated wheel package to Rackspace
-  # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
-  # disable the ssl checks.
-  - pip install wheelhouse-uploader
-  - python -m wheelhouse_uploader upload
-    --local-folder=dist --no-update-index
-    wheels
+  # Upload the generated wheel package to anaconda.org
+  # PYWAVELETS_STAGING_UPLOAD_TOKEN is an encrypted variable
+  # used in Appveyor CI config, originally created at
+  # multibuild-wheels-staging site
+  - cd ..\pywt
+  - cmd: set ANACONDA_ORG="multibuild-wheels-staging"
+  - pip install git+https://github.com/Anaconda-Server/anaconda-client
+  - IF NOT "%PYWAVELETS_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %PYWAVELETS_STAGING_UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,8 +86,8 @@ test_script:
   - python -m pip install numpy==%NP_TEST_DEP% pytest
   - python -c "import pywt; print(f'pywt version={pywt.__version__}, pywt location={pywt.__file__}')"
   - python -c "import pytest; print(f'pytest version={pytest.__version__}, ptest location={pytest.__file__}')"
-  - python -m pytest --pyargs pywt
-  # - python -c "import pywt; pywt.test()"
+  # - python -m pytest --pyargs pywt
+  - python -c "import pywt; pywt.test()"
   - cd ..
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,11 +83,8 @@ test_script:
   # Run some tests
   - mkdir tmp
   - cd tmp
-  - python -m pip install numpy==%NP_TEST_DEP% "pytest<6"
-  - python -c "import pywt; print(f'pywt version={pywt.__version__}, pywt location={pywt.__file__}')"
-  - python -c "import pytest; print(f'pytest version={pytest.__version__}, ptest location={pytest.__file__}')"
+  - python -m pip install "numpy==%NP_TEST_DEP% pytest pytest-env"
   - python -m pytest --pyargs pywt
-  # - python -c "import pywt; pywt.test()"
   - cd ..
 
 after_test:


### PR DESCRIPTION
Hi @rgommers

I am trying to update this repo so that PyWavelets can upload staging wheels to anaconda.org instead of Rackspace. I don't think we need chron job uploads, but just want to upload when PRs here are merged. 

@mattip: I saw that you recently helped the Astropy folks make the corresponding changes and would appreciate if you can provide feedback here as well, specifically on what scope is needed for the Anaconda token at `multibuild-wheels-staging`.

Here are the steps I have taken:

- Log into anaconda.org and create a new PYWAVELETS_STAGING_UPLOAD_TOKEN under the multibuild-wheels-staging organization. What are the appropriate "Scopes" to select when creating this token? I had selected "Allow all operations on Conda repositories", but am not sure that is correct. I will revoke it and regenerate as needed.

- create PYWAVELETS_STAGING_UPLOAD_TOKEN environment variables corresponding to the token at Travis-CI (at https://travis-ci.org/github/MacPython/pywavelets-wheels/settings) and Appveyor (at https://ci.appveyor.com/project/PyWavelets/pywavelets-wheels/settings/environment). 

- update the YAML scripts as in this PR to upload to anaconda.org via `anaconda-client` using the token
