### PR TITLE
retry anaconda.org upload for Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,4 +99,5 @@ on_success:
   - cd ..\pywt
   - cmd: set ANACONDA_ORG="multibuild-wheels-staging"
   - pip install git+https://github.com/Anaconda-Server/anaconda-client
+  - IF NOT "%PYWAVELETS_STAGING_UPLOAD_TOKEN%" == "" echo "anaconda token detected"
   - IF NOT "%PYWAVELETS_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %PYWAVELETS_STAGING_UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"


### PR DESCRIPTION
After merging #13 wheels from Travis did appear at anaconda.org as expected.

Windows wheels did not, but I think this is because I did not save the environment variable there properly. This PR is to try again.